### PR TITLE
`--fix` broken venvs

### DIFF
--- a/coil/__init__.py
+++ b/coil/__init__.py
@@ -1,3 +1,3 @@
 __program__ = 'coiled-venv'
-__version__ = '0.0.7'
+__version__ = '0.0.8'
 __description__ = 'Let it hatch, watch it coil (your python virtualenv)'

--- a/coil/__main__.py
+++ b/coil/__main__.py
@@ -20,6 +20,7 @@ def parseargs(args):
         '-a', '--auto', action='store_true', help='create new venv (random name) and bind it to current path'
     )
     parser.add_argument('-s', '--shed', type=str, nargs='+', help='remove these virtualenvs')
+    parser.add_argument('--fix', action='store_true', help='fix broken python binaries in virtualenv')
     parser.add_argument('--version', action='version', version=__version__)
 
     return parser.parse_args(args)
@@ -40,6 +41,13 @@ def main_wrapped(args=None):
         for v in args.shed:
             print(f'Shedding {v}')
             venv.shed(v)
+        return
+
+    if args.fix:
+        for _e in venv.list_available():
+            r = venv.fix_broken(_e)
+            if r is not False:
+                print(f'Fixed {_e}')
         return
 
     if args.bind:

--- a/coil/venv.py
+++ b/coil/venv.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Optional
 import venv as pyvenv
 import random
 import shutil
@@ -13,7 +14,7 @@ class VenvError(Exception):
     """
 
 
-def bindir(path):
+def bindir(path) -> Optional[Path]:
     d = path / 'bin'
     if d.is_dir():
         return d
@@ -26,6 +27,24 @@ def bindir(path):
 
 def check(path):
     return bindir(path) is not None
+
+
+def fix_broken(name):
+    v = C.VENV_DIR / name
+    bin = bindir(v)
+    try:
+        subprocess.check_output([bin / 'python', '--version'], stderr=subprocess.PIPE)
+        return False
+    except subprocess.CalledProcessError:
+        pass
+
+    for pe in bin.glob('python*'):
+        if pe.is_file():
+            pe.unlink()
+    for pe in bin.glob('pip*'):
+        if pe.is_file():
+            pe.unlink()
+    return new(name=name)
 
 
 def list_available():


### PR DESCRIPTION
Flag to re-create existing virtual envs with broken python links (e.g. after system python upgrade)